### PR TITLE
Implement FailureSimulator interceptor

### DIFF
--- a/shiftbooking-server/build.gradle.kts
+++ b/shiftbooking-server/build.gradle.kts
@@ -13,6 +13,7 @@ java {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(kotlin("test"))
 }

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/ShiftController.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/ShiftController.kt
@@ -1,0 +1,24 @@
+package com.harbourspace.shiftbookingserver
+
+import com.harbourspace.shiftbookingserver.interceptor.FailureSimulator
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/shifts")
+class ShiftController {
+    @FailureSimulator
+    @GetMapping
+    fun listShifts() = listOf("shift1", "shift2")
+
+    @FailureSimulator
+    @GetMapping("/{id}")
+    fun getShift(@PathVariable id: String) = "shift $id"
+
+    @FailureSimulator
+    @PostMapping
+    fun createShift() = "created"
+}

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/interceptor/FailureSimulator.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/interceptor/FailureSimulator.kt
@@ -1,0 +1,5 @@
+package com.harbourspace.shiftbookingserver.interceptor
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FailureSimulator

--- a/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/interceptor/FailureSimulatorAspect.kt
+++ b/shiftbooking-server/src/main/kotlin/com/harbourspace/shiftbookingserver/interceptor/FailureSimulatorAspect.kt
@@ -1,0 +1,25 @@
+package com.harbourspace.shiftbookingserver.interceptor
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ResponseStatusException
+
+@Aspect
+@Component
+class FailureSimulatorAspect {
+    @Around("@annotation(com.harbourspace.shiftbookingserver.interceptor.FailureSimulator)")
+    fun simulate(joinPoint: ProceedingJoinPoint): Any? {
+        val random = Math.random()
+        return when {
+            random < 0.5 -> joinPoint.proceed()
+            random < 0.8 -> throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR)
+            else -> {
+                Thread.sleep(1000)
+                joinPoint.proceed()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `@FailureSimulator` annotation
- implement `FailureSimulatorAspect` using Spring AOP
- remove old interceptor configuration
- add AOP dependency

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6845dca0bd6483248a13fdcbbb586ea3